### PR TITLE
wait-for-minio

### DIFF
--- a/wis2box-management/docker/entrypoint.sh
+++ b/wis2box-management/docker/entrypoint.sh
@@ -41,6 +41,13 @@ if [ ! -f /data/wis2box/.ssh/id_rsa ]; then
     # generate private key
     ssh-keygen -t rsa -b 4096 -f /data/wis2box/.ssh/id_rsa -N ""
     chmod 600 /data/wis2box/.ssh/id_rsa
+
+    # wait for http://minio:9000/minio/health/live to be available
+    while ! curl -s http://minio:9000/minio/health/live; do
+        echo "Waiting for minio to be available..."
+        sleep 1
+    done
+    echo "MinIO is available, proceed with setup"
 fi
 
 # wis2box commands


### PR DESCRIPTION
I suspect the  issue-910 is due to a race-condition whereby on the first startup MinIO is waiting for the wis2box-management container to create the ssh-key required to start the sftp-server

In order to avoid `wis2box environment create` to run before MinIO is ready I propose to update the entrypoint.sh to wait for MinIO after creating the ssh-key