### PR TITLE
add config for geojson-collection when dataset is published with 2geojson data-plugin

### DIFF
--- a/wis2box-management/wis2box/metadata/discovery.py
+++ b/wis2box-management/wis2box/metadata/discovery.py
@@ -358,8 +358,8 @@ def publish_discovery_metadata(metadata: Union[dict, str]):
         if metadata_id not in api_collections:
             LOGGER.info(f'Adding data-collection for: {metadata_id}')
             try:
-                from wis2box.data import gcm
-                meta = gcm(record)
+                from wis2box.data import gcm as data_gcm
+                meta = data_gcm(record)
                 setup_collection(meta=meta)
             except Exception as err:
                 LOGGER.error(f'ERROR adding data-collection for: {metadata_id}: {err}') # noqa

--- a/wis2box-management/wis2box/metadata/discovery.py
+++ b/wis2box-management/wis2box/metadata/discovery.py
@@ -346,6 +346,24 @@ def publish_discovery_metadata(metadata: Union[dict, str]):
 
     put_data(data_bytes, storage_path, 'application/geo+json')
 
+    # if 2geojson add data-collection
+    plugins = get_plugins(record)
+    # check if any plugin-names contains 2geojson
+    has_2geojson = any('2geojson' in plugin for plugin in plugins)
+    if has_2geojson:
+        api_config = load_config()
+        api_collections = api_config.list_collections()
+        metadata_id = record['id']
+        # check if metadata_id is in api_collections
+        if metadata_id not in api_collections:
+            LOGGER.info(f'Adding data-collection for: {metadata_id}')
+            try:
+                from wis2box.data import gcm
+                meta = gcm(record)
+                setup_collection(meta=meta)
+            except Exception as err:
+                LOGGER.error(f'ERROR adding data-collection for: {metadata_id}: {err}') # noqa
+
     LOGGER.debug('Publishing message')
     # check that id starts with 'urn:wmo:md:'
     if not record['id'].startswith('urn:wmo:md:'):

--- a/wis2box-management/wis2box/metadata/discovery.py
+++ b/wis2box-management/wis2box/metadata/discovery.py
@@ -36,7 +36,7 @@ from pywcmp.wcmp2.ets import WMOCoreMetadataProfileTestSuite2
 
 from wis2box import cli_helpers
 from wis2box.api import (delete_collection_item, remove_collection,
-                         setup_collection, upsert_collection_item)
+                         setup_collection, upsert_collection_item, load_config)
 from wis2box.data_mappings import refresh_data_mappings, get_plugins
 
 from wis2box.env import (API_URL, BROKER_PUBLIC, DOCKER_API_URL,


### PR DESCRIPTION
https://github.com/World-Meteorological-Organization/wis2box/issues/929

I believe this is issue is caused because we only setup the config for the geojson-collection during the container startup, this change also runs setup_collection from wis2box.api  when the dataset is created/updated