### PR TITLE
Improved metrics

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -83,6 +83,9 @@
             proxy_set_header        Authorization $http_authorization;
             proxy_pass_header       Authorization;
         }
+        location /metrics {
+            proxy_pass http://mqtt_metrics_collector:8001;
+        }
         location /mqtt {
             proxy_pass http://mosquitto:8884;
             proxy_http_version 1.1;

--- a/wis2box-broker/entrypoint.sh
+++ b/wis2box-broker/entrypoint.sh
@@ -15,6 +15,10 @@ fi
 if ! grep -q "max_queued_messages" /mosquitto/config/mosquitto.conf; then
     echo "max_queued_messages $WIS2BOX_BROKER_QUEUE_MAX" >> /mosquitto/config/mosquitto.conf
 fi
+# add log_dest topic to mosquitto.conf if not already there
+if ! grep -q "log_dest topic" /mosquitto/config/mosquitto.conf; then
+    echo "log_dest topic" >> /mosquitto/config/mosquitto.conf
+fi
 
 # prepare the acl.conf file
 if [ ! -e "/mosquitto/config/acl.conf" ]; then

--- a/wis2box-mqtt-metrics-collector/mqtt_metrics_collector.py
+++ b/wis2box-mqtt-metrics-collector/mqtt_metrics_collector.py
@@ -96,7 +96,7 @@ datasets_total = Gauge('wis2box_datasets_total',
 broker_client_total = Gauge('wis2box_broker_client_total',
                             'Total number of connected MQTT clients')
 
-broker_client_details = Gauge('wis2box_broker_client_details ',
+broker_client_details = Gauge('wis2box_broker_client_details',
                               'Total number of connected MQTT clients by client_type, username, ip_address', # noqa
                               ["client_type", "username", "ip_address"])
 


### PR DESCRIPTION
PR to add new metrics collected by mqtt-metrics-collector

New metrics added in this PR:
- Total datasets configured in wis2box
- Total number of connected MQTT clients
- Connected MQTT clients by client_type, username, ip_address

```
# HELP wis2box_datasets_total Total datasets configured in wis2box
# TYPE wis2box_datasets_total gauge
wis2box_datasets_total 3.0
# HELP wis2box_broker_client_total Total number of connected MQTT clients
# TYPE wis2box_broker_client_total gauge
wis2box_broker_client_total 2.0
# HELP wis2box_broker_client_details Total number of connected MQTT clients by client_type, username, ip_address
# TYPE wis2box_broker_client_details gauge
wis2box_broker_client_details{client_type="wis2box",ip_address="172.18.0.14",username="wis2box"} 1.0
wis2box_broker_client_details{client_type="mqtt-explorer",ip_address="193.135.216.252",username="wis2box"} 1.0
wis2box_broker_client_details{client_type="mqtt-explorer",ip_address="193.135.216.252",username="everyone"} 1.0
```