### PR TITLE
remove additional space to allow new centre-ids to be entered

### DIFF
--- a/wis2box-management/wis2box/metadata/discovery.py
+++ b/wis2box-management/wis2box/metadata/discovery.py
@@ -344,7 +344,7 @@ def publish_discovery_metadata(metadata: Union[dict, str]):
         ts.raise_for_status()
     except TestSuiteError as err:
         # if the only error is about the WIS2 topic, continue with publishing
-        if len(err.errors) == 1 and 'message' in err.errors[0] and err.errors[0]['message'] == 'Invalid WIS2 topic (unknown centre-id)  for Pub/Sub link channel': # noqa
+        if len(err.errors) == 1 and 'message' in err.errors[0] and err.errors[0]['message'] == 'Invalid WIS2 topic (unknown centre-id) for Pub/Sub link channel': # noqa
             LOGGER.warning(f"{err.errors[0]['message']} continuing with publishing")  # noqa
         else:
             msg = 'Metadata invalid, WCMP2 validation errors: ' + ', '.join([err['message'] for err in err.errors])	 # noqa


### PR DESCRIPTION
@tomkralidis  I noted that the tests in wis2box-api were broken due to the use of "invalid centre-ids", however this was not the desired behaviour as we agreed a user should still be able to configure datasets in wis2box before  their centre-id is recorded in the codes-registry.

I traced this issue to a trailing space on line 347,  that this PR removes