### PR TITLE
remove pywis-pubsub from runtime

### DIFF
--- a/wis2box-management/requirements.txt
+++ b/wis2box-management/requirements.txt
@@ -7,6 +7,5 @@ OWSLib
 paho-mqtt<2
 pygeometa
 pywcmp>=0.12.2
-pywis-pubsub
 PyYAML
 requests


### PR DESCRIPTION
This PR removes pywis-pubsub (unused) from the runtime setup (note pywis-pubsub continues to be used for testing via GitHub Actions).