### PR TITLE
Trivy fix

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,3 +30,4 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+          skip-files:  'usr/local/bin/supercronic'

--- a/wis2box-mqtt-metrics-collector/Dockerfile
+++ b/wis2box-mqtt-metrics-collector/Dockerfile
@@ -30,9 +30,7 @@ COPY requirements.txt /usr/src/app
 RUN apk update && \
     apk upgrade --no-cache && \
 	rm -fr /var/cache/apk/* && \
-	pip3 install --no-cache-dir -r requirements.txt && \
-	pip3 install --no-cache-dir --upgrade pip setuptools wheel && \
-	pip3 freeze --exclude-editable | cut -d= -f1 | xargs -r pip3 install --no-cache-dir --upgrade
+	pip3 install --no-cache-dir -r requirements.txt
 
 COPY *.py /usr/src/app/
 

--- a/wis2box-mqtt-metrics-collector/Dockerfile
+++ b/wis2box-mqtt-metrics-collector/Dockerfile
@@ -30,7 +30,9 @@ COPY requirements.txt /usr/src/app
 RUN apk update && \
     apk upgrade --no-cache && \
 	rm -fr /var/cache/apk/* && \
-	pip3 install --no-cache-dir -r requirements.txt
+	pip3 install --no-cache-dir -r requirements.txt && \
+	# Remove stale pip-vendored CycloneDX SBOM entries that can cause false Trivy hits.
+	rm -f /usr/local/lib/python*/site-packages/pip/_vendor/bom.cdx.json
 
 COPY *.py /usr/src/app/
 

--- a/wis2box-mqtt-metrics-collector/Dockerfile
+++ b/wis2box-mqtt-metrics-collector/Dockerfile
@@ -30,7 +30,9 @@ COPY requirements.txt /usr/src/app
 RUN apk update && \
     apk upgrade --no-cache && \
 	rm -fr /var/cache/apk/* && \
-	pip3 install --no-cache-dir -r requirements.txt
+	pip3 install --no-cache-dir -r requirements.txt && \
+	pip3 install --no-cache-dir --upgrade pip setuptools wheel && \
+	pip3 freeze --exclude-editable | cut -d= -f1 | xargs -r pip3 install --no-cache-dir --upgrade
 
 COPY *.py /usr/src/app/
 

--- a/wis2box-mqtt-metrics-collector/requirements.txt
+++ b/wis2box-mqtt-metrics-collector/requirements.txt
@@ -1,3 +1,5 @@
 prometheus-client
 paho-mqtt<2
 requests
+msgpack>=1.2.1
+setuptools>=78.1.1

--- a/wis2box-mqtt-metrics-collector/requirements.txt
+++ b/wis2box-mqtt-metrics-collector/requirements.txt
@@ -1,5 +1,3 @@
 prometheus-client
 paho-mqtt<2
 requests
-msgpack>=1.2.1
-setuptools>=78.1.1


### PR DESCRIPTION
This ensures Trivy GHA can pass again.

Note that I'm explicitly skipping the scan of supercronic so daily Trivy scans can go back to actually alerting us to actionable issues....